### PR TITLE
Fix compatibility with pytorch from pytorch channel

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,9 +70,9 @@ outputs:
         - {{ pin_compatible('numpy') }}
         - typing_extensions
         - __cuda  # [cuda_compiler_version != "None"]
-
       run_constrained:
-        - pytorch =*={{ proc_type }}*
+        - pytorch =*{{ proc_type }}*
+
     test:
       requires:
         - pytest


### PR DESCRIPTION
Attempt to fix dependency specification so that `mmcv-full` can be installed alongside pytorch from the pytorch channel (instead of just the conda-forge channel).

FIxes #15.